### PR TITLE
Add Linux Makefiles

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "box2d"]
 	path = box2d
-	url = git@github.com:erincatto/box2d.git
+	url = https://github.com/erincatto/box2d.git
 [submodule "SDL"]
 	path = SDL
-	url = git@github.com:libsdl-org/SDL.git
+	url = https://github.com/libsdl-org/SDL.git
 [submodule "stb"]
 	path = stb
-	url = git@github.com:nothings/stb.git
+	url = https://github.com/nothings/stb.git
 [submodule "imgui"]
 	path = imgui
-	url = git@github.com:ocornut/imgui.git
+	url = https://github.com/ocornut/imgui.git

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+
+all:
+	+$(MAKE) -C scratch_box2d
+	+$(MAKE) -C scratch_imgui
+	+$(MAKE) -C scratch
+
+strip: all
+	+$(MAKE) -C scratch $@
+
+clean:
+	+$(MAKE) -C scratch_box2d $@
+	+$(MAKE) -C scratch_imgui $@
+	+$(MAKE) -C scratch $@

--- a/README.md
+++ b/README.md
@@ -1,9 +1,41 @@
 # scratch
 
-Instructions:
+## Windows Instructions:
+
+### Visual Studio 2022:
 - `git clone https://github.com/britown88/scratch.git`
 - `cd scratch`
 - `git submodule update --init`
 - Open `scratch.sln` in Visual Studio 2022
 - Click The Green Local Windows Debugger button top center
 - Start coding in scratch/main.cpp
+
+### Microsoft C++ Build Tools:
+- [Install Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
+- Run the Visual Studio Tools Command Prompt of your choice
+- `git clone https://github.com/britown88/scratch.git`
+- `cd scratch`
+- `git submodule update --init`
+- `MSBuild "scratch.sln" /t:Clean,Build /p:Platform=x64 /p:Configuration=Release`
+
+Notes:
+- Platform can be `Win32` or `x64`
+- Configuration can be `Debug` or `Release`
+
+### Msys2:
+- [Install Msys2](https://www.msys2.org/)
+- Run your preferred MSYS2 MinGW environment
+- Install prerequisites: `pacman -S git ${MINGW_PACKAGE_PREFIX}-gcc ${MINGW_PACKAGE_PREFIX}-SDL2`
+- `git clone https://github.com/britown88/scratch.git`
+- `cd scratch`
+- `git submodule update --init`
+- `make`
+- The `scratch.exe` binary will end up in the `bin/` directory
+
+## Ubuntu/Debian Linux Instructions:
+- Install prerequisites: `sudo apt-get install git build-essential libsdl2-dev`
+- `git clone https://github.com/britown88/scratch.git`
+- `cd scratch`
+- `git submodule update --init`
+- `make`
+- The `scratch` binary will end up in the `bin/` directory

--- a/scratch/Makefile
+++ b/scratch/Makefile
@@ -1,0 +1,48 @@
+
+CC:=gcc
+CXX:=g++
+STRIP:=strip
+RM:=rm -f
+
+BASE_DIR:=..
+SRC_DIR:=.
+OBJ_DIR:=obj
+BIN_DIR:=$(BASE_DIR)/bin
+
+C_SRC:=stb_vorbis.c
+CXX_SRC:=imgui_impl_opengl3.cpp \
+    imgui_impl_sdl2.cpp \
+    main.cpp
+C_OBJ:=$(patsubst %.c, $(OBJ_DIR)/%.o, $(C_SRC))
+CXX_OBJ:=$(patsubst %.cpp, $(OBJ_DIR)/%.o, $(CXX_SRC))
+OUT:=$(BIN_DIR)/scratch
+INCLUDES:=$(INCLUDES) -I$(SRC_DIR) $(shell sdl2-config --cflags) -I$(BASE_DIR)/stb -I$(BASE_DIR)/box2d/include -I$(BASE_DIR)/imgui
+VPATH:=$(SRC_DIR):$(BASE_DIR)/stb
+CPPFLAGS:=$(CPPFLAGS) $(INCLUDES) -g -O2 -Wall
+ifeq ($(shell uname -o), Msys)
+    OUT:=$(OUT).exe
+    LDLIBS:=$(LDLIBS) -lopengl32
+else
+    LDLIBS:=$(LDLIBS) -ldl -lGL
+endif
+LDLIBS:=$(LDLIBS) $(shell sdl2-config --libs) $(BIN_DIR)/scratch_imgui.a $(BIN_DIR)/scratch_box2d.a
+
+all: $(OUT)
+
+$(C_OBJ): $(OBJ_DIR)/%.o: %.c | $(OBJ_DIR)
+	$(CC) $(CPPFLAGS) -c $< -o $@
+
+$(CXX_OBJ): $(OBJ_DIR)/%.o: %.cpp | $(OBJ_DIR)
+	$(CXX) $(CPPFLAGS) -c $< -o $@
+
+$(OUT): $(C_OBJ) $(CXX_OBJ) | $(BIN_DIR)
+	$(CXX) $(LDFLAGS) -o $@ $+ $(LDLIBS)
+
+$(OBJ_DIR) $(BIN_DIR):
+	mkdir -p $@
+
+strip: $(OUT)
+	$(STRIP) $^
+
+clean:
+	$(RM) -r $(OBJ_DIR) $(OUT)

--- a/scratch_box2d/Makefile
+++ b/scratch_box2d/Makefile
@@ -1,0 +1,74 @@
+
+CXX:=g++
+AR:=ar
+RM:=rm -f
+
+BASE_DIR:=..
+SRC_DIR:=$(BASE_DIR)/box2d/src
+OBJ_DIR:=obj
+BIN_DIR:=$(BASE_DIR)/bin
+
+SRC:=b2_broad_phase.cpp \
+    b2_chain_shape.cpp \
+    b2_circle_shape.cpp \
+    b2_collide_circle.cpp \
+    b2_collide_edge.cpp \
+    b2_collide_polygon.cpp \
+    b2_collision.cpp \
+    b2_distance.cpp \
+    b2_dynamic_tree.cpp \
+    b2_edge_shape.cpp \
+    b2_polygon_shape.cpp \
+    b2_time_of_impact.cpp \
+    b2_block_allocator.cpp \
+    b2_draw.cpp \
+    b2_math.cpp \
+    b2_settings.cpp \
+    b2_stack_allocator.cpp \
+    b2_timer.cpp \
+    b2_body.cpp \
+    b2_chain_circle_contact.cpp \
+    b2_chain_polygon_contact.cpp \
+    b2_circle_contact.cpp \
+    b2_contact.cpp \
+    b2_contact_manager.cpp \
+    b2_contact_solver.cpp \
+    b2_distance_joint.cpp \
+    b2_edge_circle_contact.cpp \
+    b2_edge_polygon_contact.cpp \
+    b2_fixture.cpp \
+    b2_friction_joint.cpp \
+    b2_gear_joint.cpp \
+    b2_island.cpp \
+    b2_joint.cpp \
+    b2_motor_joint.cpp \
+    b2_mouse_joint.cpp \
+    b2_polygon_circle_contact.cpp \
+    b2_polygon_contact.cpp \
+    b2_prismatic_joint.cpp \
+    b2_pulley_joint.cpp \
+    b2_revolute_joint.cpp \
+    b2_weld_joint.cpp \
+    b2_wheel_joint.cpp \
+    b2_world.cpp \
+    b2_world_callbacks.cpp \
+    b2_rope.cpp
+OBJ:=$(patsubst %.cpp, $(OBJ_DIR)/%.o, $(SRC))
+OUT:=$(BIN_DIR)/scratch_box2d.a
+INCLUDES:=$(INCLUDES) -I$(BASE_DIR)/box2d/include -I$(SRC_DIR)/dynamics
+VPATH:=$(SRC_DIR)/collision:$(SRC_DIR)/common:$(SRC_DIR)/dynamics:$(SRC_DIR)/rope
+CPPFLAGS:=$(CPPFLAGS) $(INCLUDES) -g -O2 -Wall
+
+all: $(OUT)
+
+$(OBJ): $(OBJ_DIR)/%.o: %.cpp | $(OBJ_DIR)
+	$(CXX) $(CPPFLAGS) -c $< -o $@
+
+$(OUT): $(OBJ) | $(BIN_DIR)
+	$(AR) rcs $@ $^
+
+$(OBJ_DIR) $(BIN_DIR):
+	mkdir -p $@
+
+clean:
+	$(RM) -r $(OBJ_DIR) $(OUT)

--- a/scratch_imgui/Makefile
+++ b/scratch_imgui/Makefile
@@ -1,0 +1,34 @@
+
+CXX:=g++
+AR:=ar
+RM:=rm -f
+
+BASE_DIR:=..
+SRC_DIR:=$(BASE_DIR)/imgui
+OBJ_DIR:=obj
+BIN_DIR:=$(BASE_DIR)/bin
+
+SRC:=imgui.cpp \
+    imgui_demo.cpp \
+    imgui_draw.cpp \
+    imgui_tables.cpp \
+    imgui_widgets.cpp
+OBJ:=$(patsubst %.cpp, $(OBJ_DIR)/%.o, $(SRC))
+OUT:=$(BIN_DIR)/scratch_imgui.a
+INCLUDES:=$(INCLUDES) -I$(SRC_DIR)
+VPATH:=$(SRC_DIR)
+CPPFLAGS:=$(CPPFLAGS) $(INCLUDES) -g -O2 -Wall
+
+all: $(OUT)
+
+$(OBJ): $(OBJ_DIR)/%.o: %.cpp | $(OBJ_DIR)
+	$(CXX) $(CPPFLAGS) -c $< -o $@
+
+$(OUT): $(OBJ) | $(BIN_DIR)
+	$(AR) rcs $@ $^
+
+$(OBJ_DIR) $(BIN_DIR):
+	mkdir -p $@
+
+clean:
+	$(RM) -r $(OBJ_DIR) $(OUT)


### PR DESCRIPTION
This should add some support for building on Linux and Msys2, along with build instructions in the Readme.

I tested the Makefiles on Xubuntu 18.04 and the latest version of Msys2, it should work on newer Debian-based, and possibly Arch-based Linux distros, but may require minor changes for other distros. The Makefiles are based on the ones I wrote for Xubuntu 20.04 earlier today, but I added some more backwards compatibility for 18.04, since there were some strange build errors with the previous Makefiles on the older version of make that's in the repo.

I also tested building with msvc build tools from the command line and added some instructions for that in the Readme as well.